### PR TITLE
Skip java/lang/Object as it's not gleanable in jigsaw

### DIFF
--- a/plexus-component-metadata/src/main/java/org/codehaus/plexus/metadata/gleaner/AnnotationComponentGleaner.java
+++ b/plexus-component-metadata/src/main/java/org/codehaus/plexus/metadata/gleaner/AnnotationComponentGleaner.java
@@ -48,6 +48,8 @@ public class AnnotationComponentGleaner
     extends ComponentGleanerSupport
     implements ClassComponentGleaner
 {
+    private static final String OBJECT_SLASHED_NAME = Object.class.getName().replace('.', '/');
+
     public ComponentDescriptor<?> glean(String className, ClassLoader cl) throws ComponentGleanerException 
     {
         assert className != null;
@@ -176,8 +178,9 @@ public class AnnotationComponentGleaner
 
         while(annClass!=null) {
             classes.add(annClass);
-            if(annClass.getSuperName()!=null) {
-              annClass = readClass2(annClass.getSuperName(), cl);
+            String superName = annClass.getSuperName();
+            if(superName!=null && !superName.equals(OBJECT_SLASHED_NAME)) {
+              annClass = readClass2(superName, cl);
             } else {
               break;
             }


### PR DESCRIPTION
http://mail-archives.apache.org/mod_mbox/maven-dev/201509.mbox/%3Cop.x4pthwhdkdkhrr%40robertscholte.dynamic.ziggo.nl%3E

> [INFO] --- plexus-component-metadata:1.6:generate-metadata (default) @ maven-model-builder ---
> [INFO] ------------------------------------------------------------------------
> [INFO] Reactor Summary:
> [INFO] 
> [INFO] Apache Maven ....................................... SUCCESS [  3.795 s]
> ...
> [INFO] Maven Model Builder ................................ FAILURE [  1.783 s]
> ...
> [INFO] ------------------------------------------------------------------------
> [INFO] BUILD FAILURE
> [INFO] ------------------------------------------------------------------------
> [ERROR] Failed to execute goal org.codehaus.plexus:plexus-component-metadata:1.6:generate-metadata (default) on project maven-model-builder: Error generating metadata: Failed to extract descriptors: Can't read class java/lang/Object: Class not found -> [Help 1]
