### PR TITLE
Fix RequirementRecipe.toString() issue, which causes incorrect error message

### DIFF
--- a/plexus-container-default/src/main/java/org/codehaus/plexus/component/builder/XBeanComponentBuilder.java
+++ b/plexus-container-default/src/main/java/org/codehaus/plexus/component/builder/XBeanComponentBuilder.java
@@ -418,7 +418,7 @@ public class XBeanComponentBuilder<T> implements ComponentBuilder<T> {
 
         @Override
         public String toString() {
-            return "RequirementRecipe[fieldName=" + requirement.getFieldName() + ", role=" + componentDescriptor.getRole() + "]";
+            return "RequirementRecipe[fieldName=" + requirement.getFieldName() + ", role=" + requirement.getRole() + "]";
         }
     }
 


### PR DESCRIPTION
this issue happens when looking up a component due to a dependent component not configured. The error message is VERY confusing since componentDescriptor is the target component instead of the dependent component.