### PR TITLE
Compatibility with the latest versions of Qdox

### DIFF
--- a/plexus-component-metadata/src/main/java/org/codehaus/plexus/metadata/gleaner/QDoxComponentGleaner.java
+++ b/plexus-component-metadata/src/main/java/org/codehaus/plexus/metadata/gleaner/QDoxComponentGleaner.java
@@ -244,7 +244,7 @@ public class QDoxComponentGleaner
         // Remove any Plexus specific interfaces from the calculation
         // ----------------------------------------------------------------------
 
-        List<JavaClass> interfaces = new ArrayList<JavaClass>(  javaClass.getImplementedInterfaces() );
+        List<JavaClass> interfaces = new ArrayList<JavaClass>(  javaClass.getInterfaces() );
 
         for ( Iterator<JavaClass> it = interfaces.iterator(); it.hasNext(); )
         {


### PR DESCRIPTION
`getImplementedInterfaces()` has been removed in Qdox 2.0-M5