### PR TITLE
Reproducible metadata

### DIFF
--- a/plexus-component-metadata/src/main/java/org/codehaus/plexus/metadata/DefaultMetadataGenerator.java
+++ b/plexus-component-metadata/src/main/java/org/codehaus/plexus/metadata/DefaultMetadataGenerator.java
@@ -28,6 +28,7 @@ import java.io.OutputStreamWriter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -100,6 +101,15 @@ public class DefaultMetadataGenerator
                 throw new Exception( "Failed to extract descriptors", e );
             }
         }
+
+        // Sort the descriptors by key to make the output reproducible
+        Collections.sort( descriptors, new Comparator<ComponentDescriptor>()
+        {
+            public int compare( ComponentDescriptor d1, ComponentDescriptor d2 )
+            {
+                return d1.getHumanReadableKey().compareTo( d2.getHumanReadableKey() );
+            }
+        });
 
         List<File> componentDescriptors = new ArrayList<File>();        
         


### PR DESCRIPTION
Hi,

The components.xml file generated by the plexus-containers-metadata plugin isn't deterministic. The output varies depending on the computer/JDK/architecture used. In order to make the output reproducible I suggest sorting the components descriptors before writing them. Here is an implementation with its unit test.

This patch has been tested in Debian as part of the [reproducible builds](https://reproducible-builds.org) effort.

Thank you