### PR TITLE
Fix typo in log message

### DIFF
--- a/plexus-component-metadata/src/main/java/org/codehaus/plexus/metadata/DefaultMetadataGenerator.java
+++ b/plexus-component-metadata/src/main/java/org/codehaus/plexus/metadata/DefaultMetadataGenerator.java
@@ -119,7 +119,7 @@ public class DefaultMetadataGenerator
         //
         if ( descriptors.size() > 0 )
         {
-            getLogger().info( "Discovered " + descriptors.size() + " component descriptors(s)" );
+            getLogger().info( "Discovered " + descriptors.size() + " component descriptor(s)" );
 
             ComponentSetDescriptor set = new ComponentSetDescriptor();
             set.setComponents( descriptors );


### PR DESCRIPTION
Wrongly prints double plural "s" like "Discovered 3 component descriptors(s)"